### PR TITLE
70 rerefactor

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Plant.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Plant.java
@@ -1,6 +1,8 @@
 package ch.uzh.ifi.hase.soprafs24.entity;
 
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import javax.persistence.*;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -25,6 +27,10 @@ public class Plant implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
+  /**
+   * Fields
+   */
+
   @Id
   @GeneratedValue
   private Long plantId;
@@ -43,13 +49,18 @@ public class Plant implements Serializable {
   @Column()
   private Integer wateringInterval;
 
-  // Relations
-  @ManyToOne
+  /**
+   * Relations
+   */
+
+  @ManyToOne(fetch = FetchType.EAGER)
   @JoinColumn(name = "user_id", nullable = false)
+  @JsonIgnore
   private User owner;
 
   @ManyToMany
   @JoinColumn(name = "plantsCaredFor")
+  @JsonIgnore
   private List<User> caretakers = new ArrayList<>();
 
   // calculate the next watering date

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Plant.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Plant.java
@@ -58,10 +58,15 @@ public class Plant implements Serializable {
   @JsonIgnore
   private User owner;
 
-  @ManyToMany
+  @ManyToMany(fetch = FetchType.EAGER)
   @JoinColumn(name = "plantsCaredFor")
   @JsonIgnore
   private List<User> caretakers = new ArrayList<>();
+
+  @ManyToOne
+  @JoinColumn(name = "space_id", nullable = true)
+  @JsonIgnore
+  private Space space;
 
   // calculate the next watering date
   public Calendar calculateAndSetNextWateringDate() {
@@ -145,5 +150,13 @@ public class Plant implements Serializable {
 
   public void setCaretakers(List<User> caretakers) {
     this.caretakers = caretakers;
+  }
+
+  public Space getSpace() {
+    return space;
+  }
+
+  public void setSpace(Space space) {
+    this.space = space;
   }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Space.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Space.java
@@ -1,0 +1,74 @@
+package ch.uzh.ifi.hase.soprafs24.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "SPACE")
+public class Space {
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Fields
+   */
+
+  @Id
+  @GeneratedValue
+  private Long spaceId;
+
+  @Column(nullable = false)
+  private String spaceName;
+
+
+  /**
+   * Relations
+   */
+
+  @ManyToOne
+  @JoinColumn(name = "user_id", nullable = false)
+  @JsonIgnore
+  private User spaceOwner;
+
+  @OneToMany(mappedBy = "plantId", orphanRemoval = false)
+  private List<Plant> plantsContained = new ArrayList<>();
+
+
+  /**
+   * getters and setters
+   */
+
+  public Long getSpaceId() {
+    return spaceId;
+  }
+
+  public void setSpaceId(Long spaceId) {
+    this.spaceId = spaceId;
+  }
+
+  public String getSpaceName() {
+    return spaceName;
+  }
+
+  public void setSpaceName(String spaceName) {
+    this.spaceName = spaceName;
+  }
+
+  public User getSpaceOwner() {
+    return spaceOwner;
+  }
+
+  public void setSpaceOwner(User spaceOwner) {
+    this.spaceOwner = spaceOwner;
+  }
+
+  public List<Plant> getPlantsContained() {
+    return plantsContained;
+  }
+
+  public void setPlantsContained(List<Plant> plantsContained) {
+    this.plantsContained = plantsContained;
+  }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/User.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/User.java
@@ -1,6 +1,8 @@
 package ch.uzh.ifi.hase.soprafs24.entity;
 
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import javax.persistence.*;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -35,14 +37,20 @@ public class User implements Serializable {
   @Column()
   private String token;
 
+  @JsonIgnore
   @Column(nullable = false)
   private String password;
 
+  /**
+   * Relations
+   */
 
-  @OneToMany(mappedBy = "owner", cascade = CascadeType.ALL, orphanRemoval = true)
+  @JsonIgnore
+  @OneToMany(fetch = FetchType.EAGER, mappedBy = "owner", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<Plant> plantsOwned = new ArrayList<>();
 
-  @ManyToMany(mappedBy = "caretakers")
+  @JsonIgnore
+  @ManyToMany(fetch = FetchType.EAGER, mappedBy = "caretakers")
   private List<Plant> plantsCaredFor = new ArrayList<>();
 
   public Long getId() {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/User.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/User.java
@@ -53,6 +53,14 @@ public class User implements Serializable {
   @ManyToMany(fetch = FetchType.EAGER, mappedBy = "caretakers")
   private List<Plant> plantsCaredFor = new ArrayList<>();
 
+  @JsonIgnore
+  @OneToMany(fetch = FetchType.EAGER, mappedBy = "spaceOwner", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<Space> spacesOwned = new ArrayList<>();
+
+  /**
+   * getters and setters
+   */
+
   public Long getId() {
     return id;
   }
@@ -107,5 +115,13 @@ public class User implements Serializable {
 
   public void setPlantsCaredFor(List<Plant> plantsCaredFor) {
     this.plantsCaredFor = plantsCaredFor;
+  }
+
+  public List<Space> getSpacesOwned() {
+    return spacesOwned;
+  }
+
+  public void setSpacesOwned(List<Space> spacesOwned) {
+    this.spacesOwned = spacesOwned;
   }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/PlantGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/PlantGetDTO.java
@@ -1,5 +1,6 @@
 package ch.uzh.ifi.hase.soprafs24.rest.dto;
 
+import ch.uzh.ifi.hase.soprafs24.entity.Space;
 import ch.uzh.ifi.hase.soprafs24.entity.User;
 
 import java.util.Date;
@@ -15,6 +16,7 @@ public class PlantGetDTO {
   private Integer wateringInterval;
   private User owner;
   private List<User> caretakers;
+  private Space space;
 
 
   public Long getPlantId() {
@@ -87,5 +89,13 @@ public class PlantGetDTO {
 
   public void setCaretakers(List<User> caretakers) {
     this.caretakers = caretakers;
+  }
+
+  public Space getSpace() {
+    return space;
+  }
+
+  public void setSpace(Space space) {
+    this.space = space;
   }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/UserGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/UserGetDTO.java
@@ -1,12 +1,18 @@
 package ch.uzh.ifi.hase.soprafs24.rest.dto;
 
 
+import ch.uzh.ifi.hase.soprafs24.entity.Plant;
+
+import java.util.List;
+
 public class UserGetDTO {
 
   private Long id;
   private String email;
   private String username;
   private String token;
+  private List<Plant> plantsOwned;
+  private List<Plant> plantsCaredFor;
 
 
   public Long getId() {
@@ -39,5 +45,21 @@ public class UserGetDTO {
 
   public void setToken(String token) {
     this.token = token;
+  }
+
+  public List<Plant> getPlantsOwned() {
+    return plantsOwned;
+  }
+
+  public void setPlantsOwned(List<Plant> plantsOwned) {
+    this.plantsOwned = plantsOwned;
+  }
+
+  public List<Plant> getPlantsCaredFor() {
+    return plantsCaredFor;
+  }
+
+  public void setPlantsCaredFor(List<Plant> plantsCaredFor) {
+    this.plantsCaredFor = plantsCaredFor;
   }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/UserGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/UserGetDTO.java
@@ -2,6 +2,7 @@ package ch.uzh.ifi.hase.soprafs24.rest.dto;
 
 
 import ch.uzh.ifi.hase.soprafs24.entity.Plant;
+import ch.uzh.ifi.hase.soprafs24.entity.Space;
 
 import java.util.List;
 
@@ -13,6 +14,7 @@ public class UserGetDTO {
   private String token;
   private List<Plant> plantsOwned;
   private List<Plant> plantsCaredFor;
+  private List<Space> spacesOwned;
 
 
   public Long getId() {
@@ -61,5 +63,13 @@ public class UserGetDTO {
 
   public void setPlantsCaredFor(List<Plant> plantsCaredFor) {
     this.plantsCaredFor = plantsCaredFor;
+  }
+
+  public List<Space> getSpacesOwned() {
+    return spacesOwned;
+  }
+
+  public void setSpacesOwned(List<Space> spacesOwned) {
+    this.spacesOwned = spacesOwned;
   }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/mapper/DTOMapper.java
@@ -31,6 +31,8 @@ public interface DTOMapper {
   @Mapping(source = "email", target = "email")
   @Mapping(source = "username", target = "username")
   @Mapping(source = "token", target = "token")
+  @Mapping(source = "plantsOwned", target = "plantsOwned")
+  @Mapping(source = "plantsCaredFor", target = "plantsCaredFor")
   UserGetDTO convertEntityToUserGetDTO(User user);
 
   @Mapping(source = "username", target = "username")

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/mapper/DTOMapper.java
@@ -57,6 +57,7 @@ public interface DTOMapper {
   @Mapping(source = "wateringInterval", target = "wateringInterval")
   @Mapping(source = "owner", target = "owner")
   @Mapping(source = "caretakers", target = "caretakers")
+  @Mapping(source = "space", target = "space")
   PlantGetDTO convertEntityToPlantGetDTO(Plant plant);
 
   @Mapping(source = "plantName", target = "plantName")

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/PlantService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/PlantService.java
@@ -91,8 +91,17 @@ public class PlantService {
       throw new RuntimeException("Can't delete nonexisting plant.");
     }
     else {
-      // TODO: check if current user is owner.
+      // Get Users that have this plant
+      User owner = plant.getOwner();
+      List<Plant> plantsOwned = owner.getPlantsOwned();
+      plantsOwned.remove(plant);
+      owner.setPlantsOwned(plantsOwned);
+
+      userRepository.saveAndFlush(owner);
+
       plantRepository.delete(plant);
+      plantRepository.flush();
+
     }
   }
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/PlantServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/PlantServiceIntegrationTest.java
@@ -117,7 +117,8 @@ public class PlantServiceIntegrationTest {
     Plant foundPlant = plantRepository.findByPlantId(createdPlant.getPlantId());
     assertEquals(foundPlant.getPlantId(), createdPlant.getPlantId());
 
-    plantRepository.delete(createdPlant);
+    //plantRepository.delete(createdPlant);
+    plantService.deletePlant(createdPlant);
 
     assertNull(plantRepository.findByPlantId(createdPlant.getPlantId()));
     userService.deleteUser(deletableOwner);


### PR DESCRIPTION
In the end my attempts at implementing everything with just userId's without breaking the db relations were futile.

There were a lot of race conditions when loading a plant from the database. It was not possible to generate the Id on the fly there. 

I opted with a solution that is not according to the plan but looks like this:

POST to localhost:8080/plants that creates a plant with one owner and two caretakers:
```json
{
    "plantName": "initialPlant",
    "species": "initialSpecies",
    "careInstructions": "Only water at night.",
    "lastWateringDate": "1910-11-09T23:00:00.000+00:00",
    "nextWateringDate": "1910-11-12T23:00:00.000+00:00",
    "wateringInterval": 3,
    "owner": {"id": 1},
    "caretakers": [{"id":2}, {"id":3}]
}
```

The following PUT will update the Plant:
```json
{
    "plantName": "initialPlant",
    "species": "initialSpecies",
    "careInstructions": "Only water at night.",
    "lastWateringDate": "1910-11-09T23:00:00.000+00:00",
    "nextWateringDate": "1910-11-12T23:00:00.000+00:00",
    "wateringInterval": 3,
    "owner": {"id": 4},
    "caretakers": [
        {"id": 1}
    ]
}
```

Additionally: 70c554b0f1407e1d2d345a89dec60edbf8166abe fixes a small bug recognised while experimenting with eager loading. 
Persisted Plants can not be deleted until also removed from the relation.