### PR TITLE
adjusted Put mapping - if no password changed

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/UserController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/UserController.java
@@ -98,7 +98,11 @@ public class UserController {
 
       user.setUsername(updatedUser.getUsername());
       user.setEmail(updatedUser.getEmail());
-      user.setPassword(userPutDTO.getPassword());
+
+      // only set the password if it is included in the DTO
+      if (userPutDTO.getPassword() != null && !userPutDTO.getPassword().isEmpty()) {
+        user.setPassword(userPutDTO.getPassword());
+      }
 
       userService.updateUser(user);
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/UserControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/UserControllerTest.java
@@ -203,6 +203,37 @@ public class UserControllerTest {
 
   }
 
+
+  /**
+   * put 204
+   */
+  @Test
+  public void updateUser_noPasswordChange_userUpdated() throws Exception {
+    // existing user
+    User existingUser = new User();
+    existingUser.setId(1L);
+    existingUser.setUsername("testUser");
+    existingUser.setEmail("asdf@plantparent.ch");
+    existingUser.setPassword("asdf");
+
+    UserPutDTO userPutDTO = new UserPutDTO();
+    userPutDTO.setUsername("Fancy Username");
+    userPutDTO.setEmail("ddd@plantparent.ch");
+
+    given(userService.updateUser(Mockito.any())).willReturn(existingUser);
+    given(userService.getUserById(Mockito.any())).willReturn(existingUser);
+
+
+    // when/then -> put the new user, then check the changed user
+    MockHttpServletRequestBuilder putRequest = put("/users/1")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(asJsonString(userPutDTO));
+
+    mockMvc.perform(putRequest).andExpect(status().isNoContent());
+
+  }
+
+
   /**
    * put 404
    */

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/UserServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/UserServiceIntegrationTest.java
@@ -126,6 +126,28 @@ public class UserServiceIntegrationTest {
   }
 
   @Test
+  public void udpateUser_noPasswordChange_success() {
+    assertNull(userRepository.findByUsername("testUsername"));
+
+    User testUser = new User();
+    testUser.setEmail("testUser@email.com");
+    testUser.setUsername("testUsername");
+    testUser.setPassword("password");
+    User createdUser = userService.createUser(testUser);
+
+    createdUser.setEmail("other@mail.com");
+    createdUser.setUsername("otherName");
+
+    User updatedUser = userService.updateUser(createdUser);
+
+    assertEquals(createdUser.getId(), updatedUser.getId());
+    assertEquals(createdUser.getEmail(), updatedUser.getEmail());
+    assertEquals(createdUser.getUsername(), updatedUser.getUsername());
+    assertEquals(createdUser.getPassword(), updatedUser.getPassword());
+
+  }
+
+  @Test
   public void loginUser_validInput_success() {
     
     assertNull(userRepository.findByUsername("testUsername"));


### PR DESCRIPTION
Adjusted the Controller mapping for updating user, so that it only sets the password field, if a new password is being set otherwise no password is required to be sent to the endpoint 