### PR TITLE
fix the return of duplicate plants

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/User.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/User.java
@@ -46,11 +46,11 @@ public class User implements Serializable {
    */
 
   @JsonIgnore
-  @OneToMany(fetch = FetchType.EAGER, mappedBy = "owner", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OneToMany(fetch = FetchType.LAZY, mappedBy = "owner", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<Plant> plantsOwned = new ArrayList<>();
 
   @JsonIgnore
-  @ManyToMany(fetch = FetchType.EAGER, mappedBy = "caretakers")
+  @ManyToMany(fetch = FetchType.LAZY, mappedBy = "caretakers")
   private List<Plant> plantsCaredFor = new ArrayList<>();
 
   @JsonIgnore

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/PlantServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/PlantServiceIntegrationTest.java
@@ -420,6 +420,7 @@ public class PlantServiceIntegrationTest {
       assertTrue(plantService.generateEmailMessagesForOverduePlants().isEmpty());
   }
 
+  @Transactional
   @Test
   public void waterThisPlant_fieldsUpdated() {
     User myUser = new User();
@@ -460,6 +461,7 @@ public class PlantServiceIntegrationTest {
     userService.deleteUser(myUser);
   }
 
+  @Transactional
   @Test
   public void careForThisPlant_fieldsUpdated() {
     User myUser = new User();


### PR DESCRIPTION
* Had to change the fetchType to LAZY on the non-owning side of the relations, so that the returned lists get properly populated and no duplicates get returned. 
* The issue of duplicate plants occured both in the plantsOwned and the plantsCaredFor list
* I already had this issue with the plantsContained list for spaces and changing the fetchtype on one side resolved the issue
