### PR TITLE
[#143] Implement persistent GCP SQL backend for GAE app

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,8 @@ jobs:
           deliverables: app.yaml
           version: v1
           credentials: ${{ secrets.GCP_SERVICE_CREDENTIALS }}
+          env_vars: |-
+            spring_profiles_active=gcp
 
       - name: Test
         run: curl "${{ steps.deploy.outputs.url }}"

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,9 @@ springBoot {
     mainClass.set('ch.uzh.ifi.hase.soprafs24.Application')
 }
 
+// This is used to steer the dependencies. Some GCP dependencies try to greedely start an SQL DB.
+String profile = System.getenv("spring_profiles_active")
+
 dependencies {
     implementation 'org.mapstruct:mapstruct:1.3.1.Final'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.3.1.Final'
@@ -49,12 +52,25 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.5.2'
 
   // GCP dependencies
-  implementation 'com.google.cloud:google-cloud-secretmanager:2.42.0'
-  implementation platform('com.google.cloud:libraries-bom:26.38.0')
-  implementation 'com.google.cloud:google-cloud-storage'
+  implementation 'com.google.cloud:google-cloud-secretmanager:2.42.0' // 	Apr 26, 2024
+  //implementation 'com.google.cloud:google-cloud-secretmanager:2.27.0' // 		May 11, 2023
+  //implementation platform('com.google.cloud:libraries-bom:26.38.0') // 	Apr 30, 2024
+  implementation 'com.google.cloud:libraries-bom:26.14.0' // May 03, 2023
+  //implementation 'com.google.cloud:google-cloud-storage'
+  implementation 'com.google.cloud:google-cloud-storage:2.22.2' // 	May 10, 2023
 
     // https://mvnrepository.com/artifact/commons-io/commons-io
     implementation 'commons-io:commons-io:2.6'
+
+  // Some of the GCP dependencies try to greedely start a session. This conflicts with H2.
+  if (profile == 'gcp') {
+    // GCP SQL dependencies
+    implementation("com.google.cloud:spring-cloud-gcp-dependencies:5.2.1")
+    implementation 'com.google.cloud:spring-cloud-gcp-starter-sql-mysql:5.2.1'
+    implementation 'com.google.cloud:spring-cloud-gcp-starter-secretmanager:5.2.1'
+
+    implementation 'org.springframework.cloud:spring-cloud-starter-bootstrap:4.1.2'
+  }
 }
 
 bootJar {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/config/DatabaseLoader.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/config/DatabaseLoader.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
@@ -19,8 +21,9 @@ import ch.uzh.ifi.hase.soprafs24.repository.UserRepository;
 @Component
 public class DatabaseLoader implements CommandLineRunner{
 
-    private final UserRepository userRepository;
-    private final PlantRepository plantRepository;
+  private static final Logger LOGGER = LoggerFactory.getLogger(DatabaseLoader.class);
+  private final UserRepository userRepository;
+  private final PlantRepository plantRepository;
   private final SpaceRepository spaceRepository;
 
     @Autowired
@@ -34,6 +37,8 @@ public class DatabaseLoader implements CommandLineRunner{
     @Transactional
     public void run(String... args) throws Exception {
         if (userRepository.count() == 0) { // Check if data needs to be initialized
+          LOGGER.info("Database is empty so it is initialized.");
+
             User initialUser = new User();
           initialUser.setEmail("initialUser@muell.icu");
             initialUser.setUsername("initialUser");
@@ -199,6 +204,9 @@ public class DatabaseLoader implements CommandLineRunner{
           spaceRepository.save(hallway);
           userRepository.save(secondUser);
           plantRepository.save(fifthPlant);
+        }
+        else {
+          LOGGER.info("Database is not empty. No Data is initialized.");
         }
     }
 }

--- a/src/main/resources/application-gcp.properties
+++ b/src/main/resources/application-gcp.properties
@@ -1,0 +1,18 @@
+spring.cloud.gcp.project-id=sopra-fs24-group-01-server
+
+# GCP SQL config
+spring.config.import=sm://
+# Connection information
+spring.datasource.url=sopra-fs24-group-01-server:europe-west6:plant-parent-db
+spring.datasource.username=test-user
+spring.datasource.password=${sm://projects/549476443324/secrets/gcp-sql-plantparent-key}
+# DB information
+spring.cloud.gcp.sql.database-name=plant_parent_server_db
+spring.cloud.gcp.sql.instance-connection-name=sopra-fs24-group-01-server:europe-west6:plant-parent-db
+# Configuration on how the situation is handeled for schema discrepance between JPA and Cloud SQL
+spring.jpa.properties.javax.persistence.schema-generation.database.action=update
+spring.jpa.properties.javax.persistence.schema-generation.create-database-schemas=true
+spring.jpa.properties.javax.persistence.schema-generation.create-source=metadata
+# multipart image upload config for GCP
+spring.servlet.multipart.max-file-size=6MB
+spring.servlet.multipart.max-request-size=6MB

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,0 +1,9 @@
+# Enabling the H2-Console (local and remote)
+spring.h2.console.enabled=true
+spring.h2.console.settings.web-allow-others=true
+# Password for the H2-Console
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,16 +1,5 @@
 server.port=8080
 
-# Enabling the H2-Console (local and remote)
-spring.h2.console.enabled=true
-spring.h2.console.settings.web-allow-others=true
-
-# Password for the H2-Console
-spring.datasource.url=jdbc:h2:mem:testdb
-spring.datasource.driver-class-name=org.h2.Driver
-spring.datasource.username=sa
-spring.datasource.password=
-spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
-
 # You can find your h2-console at: http://localhost:8080/h2-console/
 # If you changed the server.port, you must also change it in the URL
 # The credentials to log in to the h2 Driver are defined above. Be aware that the h2-console is only accessible when the server is running.

--- a/src/main/resources/bootstrap.properties
+++ b/src/main/resources/bootstrap.properties
@@ -1,0 +1,2 @@
+spring.cloud.gcp.secretmanager.enabled=true
+spring.cloud.gcp.secretmanager.bootstrap.enabled=true


### PR DESCRIPTION
Introduction of specific spring profiles:
* gcp: The application deployed on GAE
* local: Local development mode with H2 backend.

This can be changed via adding the environment variable `spring_profiles_active=local` to the run configuration.

Closes #143