### PR TITLE
[#143] Upgrade deploy-appengine from v0.2.0 to v2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Deploy to App Engine
         id: deploy
-        uses: google-github-actions/deploy-appengine@v0.2.0
+        uses: google-github-actions/deploy-appengine@v2
         with:
           deliverables: app.yaml
           version: v1


### PR DESCRIPTION
Necessary so env_vars actually does anything.