### PR TITLE
[#143] Configure auth action for GH action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,13 +38,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Authenticate to Google
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SERVICE_CREDENTIALS }}
+
       - name: Deploy to App Engine
         id: deploy
         uses: google-github-actions/deploy-appengine@v2
         with:
           deliverables: app.yaml
           version: v1
-          credentials: ${{ secrets.GCP_SERVICE_CREDENTIALS }}
           env_vars: |-
             spring_profiles_active=gcp
 


### PR DESCRIPTION
deploy-appengine action v2 does not support the previous direct authentication via token. This is now done via auth action according to this documentation: https://github.com/google-github-actions/deploy-appengine