### PR TITLE
[#143] Reconfigure spring profiles to accommodate gcp secret manager

### DIFF
--- a/src/main/resources/application-gcp.properties
+++ b/src/main/resources/application-gcp.properties
@@ -1,4 +1,6 @@
 spring.cloud.gcp.project-id=sopra-fs24-group-01-server
+spring.cloud.gcp.secretmanager.enabled=true
+spring.cloud.gcp.secretmanager.bootstrap.enabled=true
 
 # GCP SQL config
 spring.config.import=sm://

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,16 +1,10 @@
 server.port=8080
 
-# You can find your h2-console at: http://localhost:8080/h2-console/
-# If you changed the server.port, you must also change it in the URL
-# The credentials to log in to the h2 Driver are defined above. Be aware that the h2-console is only accessible when the server is running.
 
-# multipart image upload
 spring.servlet.multipart.max-file-size=2MB
 spring.servlet.multipart.max-request-size=2MB
-# GCP Bucket config
 gcp.bucket.name=plant-profiles-b7f9f9f1-445b
 gcp.project.id=sopra-fs24-group-01-server
-# set these to true for debuggin purposes
-# shows the sql statements performed by jpa and hibernate
 spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.format_sql=false
+

--- a/src/main/resources/bootstrap.properties
+++ b/src/main/resources/bootstrap.properties
@@ -1,2 +1,0 @@
-spring.cloud.gcp.secretmanager.enabled=true
-spring.cloud.gcp.secretmanager.bootstrap.enabled=true


### PR DESCRIPTION
Some of the mechanisms, such as bootstrap.properties, used were are deprecated: https://stackoverflow.com/questions/67507452/no-spring-config-import-property-has-been-defined

Welcome to dependency hell....