### PR TITLE
[#143] Remove spring.config.import

### DIFF
--- a/src/main/resources/application-gcp.properties
+++ b/src/main/resources/application-gcp.properties
@@ -3,7 +3,7 @@ spring.cloud.gcp.secretmanager.enabled=true
 spring.cloud.gcp.secretmanager.bootstrap.enabled=true
 
 # GCP SQL config
-spring.config.import=sm://
+#spring.config.import=optional:sm://
 # Connection information
 spring.datasource.url=sopra-fs24-group-01-server:europe-west6:plant-parent-db
 spring.datasource.username=test-user


### PR DESCRIPTION
GAE throws the following exception:
org.springframework.boot.context.config.ConfigDataLocationNotFoundException: Config data location 'sm://' cannot be found