### PR TITLE
Improvement creating plant in space

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/PlantController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/PlantController.java
@@ -13,8 +13,11 @@ import ch.uzh.ifi.hase.soprafs24.rest.dto.EmailMessageDTO;
 import ch.uzh.ifi.hase.soprafs24.rest.mapper.DTOMapper;
 import ch.uzh.ifi.hase.soprafs24.service.GCPStorageService;
 import ch.uzh.ifi.hase.soprafs24.service.PlantService;
+import ch.uzh.ifi.hase.soprafs24.service.SpaceService;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.checkerframework.checker.units.qual.s;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
@@ -37,10 +40,12 @@ import org.springframework.web.bind.annotation.RequestBody;
 @RestController
 public class PlantController {
   private final PlantService plantService;
+  private final SpaceService spaceService;
   private final GCPStorageService gcpStorageService;
 
-  PlantController(PlantService plantService, GCPStorageService gcpStorageService) {
+  PlantController(PlantService plantService, SpaceService spaceService, GCPStorageService gcpStorageService) {
     this.plantService = plantService;
+    this.spaceService = spaceService;
     this.gcpStorageService = gcpStorageService;
   }
 
@@ -78,10 +83,15 @@ public class PlantController {
   @PostMapping("/plants")
   @ResponseStatus(HttpStatus.CREATED)
   @ResponseBody
-  public PlantGetDTO createPlant(@RequestBody PlantPostDTO plantPostDTO) {
+  public PlantGetDTO createPlant(@RequestBody PlantPostDTO plantPostDTO,
+                                @RequestParam(required = false) Long spaceId) {
     Plant createInput = DTOMapper.INSTANCE.convertPlantPostDTOtoEntity(plantPostDTO);
 
     Plant createdPlant = plantService.createPlant(createInput);
+
+    if (spaceId != null) {
+      spaceService.addPlantToSpace(createdPlant.getPlantId(), spaceId);
+    }
 
     return DTOMapper.INSTANCE.convertEntityToPlantGetDTO(createdPlant);
   }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/SpaceService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/SpaceService.java
@@ -208,9 +208,22 @@ public class SpaceService {
       throw new RuntimeException("This plant with id " + plantId + " is already added to this space with id " + spaceId);
     }
 
-    // add user to member list of space
+    // add plant to plantsContained list of space
     space.getPlantsContained().add(plant);
     plant.setSpace(space);
+
+    // ensure all members become caretakers of new plant
+    for (User member : space.getSpaceMembers()) {
+      if (!plant.getCaretakers().contains(member) && !member.equals(plant.getOwner())) {
+        plant.getCaretakers().add(member);
+        member.getPlantsCaredFor().add(plant);
+      }
+    }
+    // if the plant wasn't added by the spaceOwner we have to also add it 
+    if (!space.getSpaceOwner().equals(plant.getOwner())) {
+      plant.getCaretakers().add(space.getSpaceOwner());
+      space.getSpaceOwner().getPlantsCaredFor().add(plant);
+    }
 
     // save the updated space and plant entities
     spaceRepository.save(space);
@@ -228,9 +241,23 @@ public class SpaceService {
       throw new RuntimeException("Cannot remove plant from a space which does not contain it.");
     }
 
-    // remove user from space
+    // remove plant from space
     space.getPlantsContained().remove(plant);
     plant.setSpace(null);
+
+    // Remove the plant from the plantsCaredFor list of all members
+    for (User member : space.getSpaceMembers()) {
+    if (plant.getCaretakers().contains(member)) {
+        plant.getCaretakers().remove(member);
+        member.getPlantsCaredFor().remove(plant);
+      }
+    }
+
+  // If the plant wasn't owned by the spaceOwner, also update the spaceOwner's plantsCaredFor list
+  if (!space.getSpaceOwner().equals(plant.getOwner()) && plant.getCaretakers().contains(space.getSpaceOwner())) {
+      plant.getCaretakers().remove(space.getSpaceOwner());
+      space.getSpaceOwner().getPlantsCaredFor().remove(plant);
+  }
 
     // save the updated space and plant entities
     spaceRepository.save(space);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/SpaceService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/SpaceService.java
@@ -219,8 +219,8 @@ public class SpaceService {
         member.getPlantsCaredFor().add(plant);
       }
     }
-    // if the plant wasn't added by the spaceOwner we have to also add it 
-    if (!space.getSpaceOwner().equals(plant.getOwner())) {
+    // if the plant wasn't added by the spaceOwner we have to also add the spaceOwner as caretaker
+    if (!space.getSpaceOwner().equals(plant.getOwner()) && !plant.getCaretakers().contains(space.getSpaceOwner())) {
       plant.getCaretakers().add(space.getSpaceOwner());
       space.getSpaceOwner().getPlantsCaredFor().add(plant);
     }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/PlantControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/PlantControllerTest.java
@@ -224,6 +224,30 @@ public class PlantControllerTest {
   }
 
   /**
+   * post new plant, 201
+   */
+  @Test
+  public void createPlant_withinSpace_plantCreated() throws Exception {
+    given(plantService.createPlant(Mockito.any())).willReturn(testPlant);
+    doNothing().when(spaceService).addPlantToSpace(Mockito.any(), Mockito.any());
+
+    PlantPostDTO plantPostDTO = new PlantPostDTO();
+    plantPostDTO.setPlantName(testPlant.getPlantName());
+    Long spaceId = 55L;
+
+    MockHttpServletRequestBuilder postRequest = post("/plants")
+            .param("spaceId", spaceId.toString())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(asJsonString(plantPostDTO));
+
+    mockMvc.perform(postRequest)
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.plantName", is(testPlant.getPlantName())));
+
+    verify(spaceService).addPlantToSpace(testPlant.getPlantId(), spaceId);
+  }
+
+  /**
    * update existing plant, 204
    */
   @Test

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/PlantControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/PlantControllerTest.java
@@ -13,7 +13,7 @@ import ch.uzh.ifi.hase.soprafs24.rest.dto.SpaceAssignmentPostDTO;
 import ch.uzh.ifi.hase.soprafs24.rest.mapper.DTOMapper;
 import ch.uzh.ifi.hase.soprafs24.service.GCPStorageService;
 import ch.uzh.ifi.hase.soprafs24.service.PlantService;
-
+import ch.uzh.ifi.hase.soprafs24.service.SpaceService;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -22,6 +22,7 @@ import org.checkerframework.checker.units.qual.t;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -66,6 +67,9 @@ public class PlantControllerTest {
 
   @MockBean
   private PlantService plantService;
+
+  @MockBean
+  private SpaceService spaceService;
 
   @MockBean
   private GCPStorageService gcpStorageService;


### PR DESCRIPTION
* Adjusted the plant creation endpoint to take a optional parameter spaceId that can be passed in when a plant is created within a space. If this parameter is present the addPlantToSpace function will be called after the plant creation.
* With regards to #189, i added the code to ensure this happens, this also includes the assignment of the spaceOwner as caretaker if the plant added to the space is not owned by the spaceOwner (this was missed previously, as we only went over the spaceMembers list)
* added some tests for the changes
* For #192 i added a test to ensure this does not happen, but the check was already present in the code, so the issue may lie somewhere else 